### PR TITLE
Add Calva start and connect configuration

### DIFF
--- a/.clj-kondo/hyperfiddle/electric/config.edn
+++ b/.clj-kondo/hyperfiddle/electric/config.edn
@@ -1,0 +1,6 @@
+{:lint-as {hyperfiddle.electric/def        clojure.core/def
+           hyperfiddle.electric/defn       clojure.core/defn
+           hyperfiddle.electric/for        clojure.core/for
+           hyperfiddle.electric/with-cycle clojure.core/let
+           hyperfiddle.electric/fn         clojure.core/fn}
+ :linters {:redundant-expression {:level :off}}}

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ clj/**/pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
-.lsp/
+.lsp/.cache
+.clj-kondo/.cache
 clj/data/
 clj/target/
 java/data/
@@ -20,7 +21,6 @@ java/target/
 java/.classpath
 java/.project
 .settings/
-.vscode/
 *.~undo-tree~
 .DS_Store
 /data/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "calva.replConnectSequences": [
+        {
+            "name": "Electric XTDB Starter App",
+            "projectType": "shadow-cljs",
+            "cljsType": "shadow-cljs",
+            "jackInEnv": {"XTDB_ENABLE_BYTEUTILS_SHA1": "true"},
+            "projectRootPath": ["."],
+            "autoSelectForJackIn": true,
+            "autoSelectForConnect": true,
+            "afterCLJReplJackInCode": "(require '[user]) (user/main)",
+            "menuSelections": {
+                "cljsLaunchBuilds": ["dev"],
+                "cljsDefaultBuild": "dev"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ shadow-cljs - nREPL server started on port 9001
 
 👉 App server available at http://0.0.0.0:8080
 ```
+
+## Using Calva?
+
+If you are using Calva you can start the app like this instead:
+
+0. Open the project in VS Code
+1. Issue the command **Calva: Start a Project REPL and Connect (a.k.a Jack-in)
+
+When "👉 App server available at http://0.0.0.0:8080" is printed in the Calva output/REPL window, you can control/cmd-click it and Calva will be connected both to the server and the client parts of the app.


### PR DESCRIPTION
This adds a configuration so that starting the app and connecting Calva to both the server and the client is a one-command (Jack-in) thing.

(On my machine I also had to comment out the hardcoded nrepl port, because I have many nrepl servers started. Not sure why it is hardcoded to begin with, so I didn't include that in the PR. But I think having it there risks adding friction.